### PR TITLE
Add ability for OTel to append traceparent span and multi-host connection load testing

### DIFF
--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -42,10 +42,11 @@ All configuration is via environment variables, loaded from a `.env` file. See `
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DB_NAME` | No | `bluebox` | PostgreSQL database name |
-| `DB_HOST` | No | `localhost` | Database host |
+| `DB_HOST` | No | `localhost` | Database host. Comma-separated for HA (see below) |
 | `DB_USER` | No | `postgres` | Database user |
 | `DB_PASSWORD` | No | `password` | Database password |
 | `DB_PORT` | No | `5432` | Database port |
+| `DB_TARGET_SESSION_ATTRS` | No | `any` | libpq target_session_attrs. Set to `read-write` with a multi-host `DB_HOST` to follow the primary across a failover |
 | `POOL_MIN_SIZE` | No | `2` | Minimum connections in pool |
 | `POOL_MAX_SIZE` | No | `10` | Maximum connections in pool |
 | `WORKER_THREADS` | No | `4` | Number of concurrent dispatch threads |
@@ -54,6 +55,18 @@ All configuration is via environment variables, loaded from a `.env` file. See `
 | `NIGHT_MULTIPLIER` | No | `0.1` | RPM multiplier for 00:00-06:00 |
 | `EVENING_MULTIPLIER` | No | `2.5` | RPM multiplier for 17:00-21:00 |
 | `HOLIDAY_MULTIPLIER` | No | `3.0` | Additional multiplier on holidays |
+
+### HA clusters (Patroni, etc.)
+
+To run the generator against an HA cluster that can change writer/reader roles, list every cluster member in `DB_HOST` and set `DB_TARGET_SESSION_ATTRS=read-write`:
+
+```
+DB_HOST=node1,node2,node3
+DB_PORT=5432
+DB_TARGET_SESSION_ATTRS=read-write
+```
+
+libpq tries each host in turn and only accepts one where `pg_is_in_recovery()` is false — i.e. the current primary. After a failover, queries already in flight will raise (one logged error per affected scenario); the pool validates connections on checkout, discards any conn still pointed at the old primary, and the next worker iteration reconnects to the new leader. No proxy or HAProxy required for this setup. The pool already disables server-side prepared statements (`prepare_threshold=None`), which is also what you want across failover.
 
 ### OpenTelemetry (optional)
 

--- a/load-testing/.env.example
+++ b/load-testing/.env.example
@@ -5,6 +5,13 @@ DB_USER=postgres
 DB_PASSWORD=password
 DB_PORT=5432
 
+# HA / failover (optional). For a Patroni-style cluster, set DB_HOST to a
+# comma-separated list of cluster members and DB_TARGET_SESSION_ATTRS to
+# "read-write" — libpq will probe each host and connect to the current
+# primary, and find the new leader after a failover.
+# DB_HOST=node1,node2,node3
+# DB_TARGET_SESSION_ATTRS=read-write
+
 # Connection pool sizing
 # POOL_MIN_SIZE=2
 # POOL_MAX_SIZE=10

--- a/load-testing/scripts/otel_smoke_test.py
+++ b/load-testing/scripts/otel_smoke_test.py
@@ -1,0 +1,91 @@
+"""Smoke test for OTel tracing configuration.
+
+Initializes tracing using the same config the load runner uses, emits
+a single test span with a few attributes, runs a real DB query (so
+psycopg's sqlcommenter appends the traceparent), then dumps the recent
+pg_stat_activity entry so you can visually confirm the trace context
+made it into the SQL. Flushes spans and exits.
+
+Run with: uv run python scripts/otel_smoke_test.py
+"""
+
+import logging
+import time
+
+from bluebox_load.config import load_config
+from bluebox_load.db import close_pool, connection, init_pool
+from bluebox_load.tracing import init_tracing, server_span, shutdown_tracing
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    log = logging.getLogger("otel-smoke-test")
+
+    config = load_config()
+
+    if not config.otel_enabled:
+        log.error("OTEL_EXPORTER_OTLP_ENDPOINT is not set in .env — nothing to test.")
+        return
+
+    log.info("Endpoint: %s", config.otel_endpoint)
+    log.info("Service name: %s", config.otel_service_name)
+    log.info("Headers configured: %s", bool(config.otel_headers))
+
+    init_tracing(config)
+    init_pool(config)
+
+    with server_span("GET", "/smoke-test", **{"smoke_test": True, "test_run_id": "manual"}) as span:
+        if span:
+            span.set_attribute("note", "If you see this in your tracing backend, OTel is wired up correctly")
+
+        # Run a marker query so the traceparent comment is appended.
+        # The unique literal makes it easy to find the matching row.
+        marker = f"otel-smoke-{int(time.time())}"
+        with connection() as conn:
+            cur = conn.cursor()
+            cur.execute("SELECT %s AS marker, pg_backend_pid() AS pid", (marker,))
+            row = cur.fetchone()
+            backend_pid = row[1]
+            cur.close()
+        log.info("Marker query executed (pid=%s, marker=%s)", backend_pid, marker)
+
+        # Look up the query text in pg_stat_activity to verify the comment landed.
+        # We query from a separate connection so we see the prior session's last query.
+        with connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """SELECT query
+                   FROM pg_stat_activity
+                   WHERE query LIKE %s
+                   ORDER BY query_start DESC NULLS LAST
+                   LIMIT 1""",
+                (f"%{marker}%",),
+            )
+            found = cur.fetchone()
+            cur.close()
+
+        if found:
+            query_text = found[0]
+            log.info("Recovered query text from pg_stat_activity:")
+            log.info("  %s", query_text)
+            if "traceparent" in query_text:
+                log.info("SUCCESS: traceparent comment is present in the executed query.")
+            else:
+                log.warning(
+                    "Query found, but no 'traceparent' comment detected. "
+                    "Check that PsycopgInstrumentor was initialized with enable_commenter=True."
+                )
+        else:
+            log.warning(
+                "Could not find the marker query in pg_stat_activity — it may have already aged out. "
+                "Try increasing the marker query work or run again."
+            )
+
+    log.info("Flushing spans...")
+    shutdown_tracing()
+    close_pool()
+    log.info("Done. Check your tracing backend for a span named 'GET /smoke-test'.")
+
+
+if __name__ == "__main__":
+    main()

--- a/load-testing/src/bluebox_load/config.py
+++ b/load-testing/src/bluebox_load/config.py
@@ -17,6 +17,9 @@ class Config:
     db_user: str = "postgres"
     db_password: str = "password"
     db_port: int = 5432
+    # libpq target_session_attrs. Use "read-write" with a comma-separated
+    # DB_HOST to follow the primary across an HA failover (e.g. Patroni).
+    db_target_session_attrs: str = "any"
 
     # Connection pool
     pool_min_size: int = 2
@@ -75,6 +78,7 @@ def load_config(env_file: str | None = None) -> Config:
         db_user=os.getenv("DB_USER", "postgres"),
         db_password=os.getenv("DB_PASSWORD", "password"),
         db_port=int(os.getenv("DB_PORT", "5432")),
+        db_target_session_attrs=os.getenv("DB_TARGET_SESSION_ATTRS", "any"),
         pool_min_size=int(os.getenv("POOL_MIN_SIZE", "2")),
         pool_max_size=int(os.getenv("POOL_MAX_SIZE", "10")),
         worker_threads=int(os.getenv("WORKER_THREADS", "4")),

--- a/load-testing/src/bluebox_load/db.py
+++ b/load-testing/src/bluebox_load/db.py
@@ -17,6 +17,10 @@ def init_pool(config: Config) -> ConnectionPool:
 
     The pool sets search_path to 'bluebox,public' so that
     unqualified table names resolve to the bluebox schema first.
+
+    DB_HOST may be a comma-separated list (e.g. "node1,node2,node3"); combined
+    with DB_TARGET_SESSION_ATTRS=read-write this lets libpq find the current
+    primary across a Patroni-style failover.
     """
     global _pool
 
@@ -26,13 +30,15 @@ def init_pool(config: Config) -> ConnectionPool:
         f"port={config.db_port} "
         f"user={config.db_user} "
         f"password={config.db_password} "
+        f"target_session_attrs={config.db_target_session_attrs} "
         f"options=-csearch_path=bluebox,public"
     )
 
     log.info(
-        "Initializing connection pool (%d-%d connections) to %s@%s:%d/%s",
+        "Initializing connection pool (%d-%d connections) to %s@%s:%d/%s (target_session_attrs=%s)",
         config.pool_min_size, config.pool_max_size,
         config.db_user, config.db_host, config.db_port, config.db_name,
+        config.db_target_session_attrs,
     )
 
     _pool = ConnectionPool(
@@ -40,6 +46,10 @@ def init_pool(config: Config) -> ConnectionPool:
         min_size=config.pool_min_size,
         max_size=config.pool_max_size,
         open=True,
+        # Validate connections on checkout so a conn that was open against the
+        # old primary at the moment of failover gets discarded and replaced
+        # rather than handed to a worker that's about to throw.
+        check=ConnectionPool.check_connection,
         kwargs={
             "autocommit": True,
             "prepare_threshold": None,

--- a/load-testing/src/bluebox_load/tracing.py
+++ b/load-testing/src/bluebox_load/tracing.py
@@ -52,7 +52,7 @@ def init_tracing(config: Config) -> None:
 
     _tracer = trace.get_tracer("bluebox-load")
 
-    PsycopgInstrumentor().instrument()
+    PsycopgInstrumentor().instrument(enable_commenter=True, commenter_options={})
 
     log.info("OTel tracing initialized (endpoint=%s, service=%s)",
              config.otel_endpoint, config.otel_service_name)


### PR DESCRIPTION
For OTel load testing with pganalyze we needed to send the traceparent span to correlate the span with the EXPLAIN plan.

On HA clusters (eg. Patroni), add the ability for the load testing suite to find the leader via libpq probe for read-write.